### PR TITLE
DS from scratch: basic infrastructure for Clojure (Clerk) notebooks.

### DIFF
--- a/data-science-from-scratch/README.md
+++ b/data-science-from-scratch/README.md
@@ -1,0 +1,2 @@
+Examples from the excellent O'Reilly book Data Science from Scratch:
+https://www.oreilly.com/library/view/data-science-from/9781492041122/

--- a/data-science-from-scratch/clojure/deps.edn
+++ b/data-science-from-scratch/clojure/deps.edn
@@ -1,0 +1,6 @@
+{:deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        ;; clerk - notebooks: https://github.com/nextjournal/clerk
+        io.github.nextjournal/clerk {:mvn/version "0.8.451"}
+        ;; https://github.com/ngrunwald/meta-csv
+        meta-csv/meta-csv {:mvn/version "0.1.0"}
+}}

--- a/data-science-from-scratch/clojure/src/notebooks.clj
+++ b/data-science-from-scratch/clojure/src/notebooks.clj
@@ -1,0 +1,17 @@
+(ns notebooks.notebooks
+  (:require [nextjournal.clerk :as clerk]))
+
+;;; Clerk demo: https://github.com/nextjournal/clerk#-using-clerk
+;;; see notebooks: https://github.com/nextjournal/clerk/blob/main/notebooks
+;;; - these notebooks have been copied to src/clojure_experiments/visualizations/clerk/notebooks/
+(comment
+;; start Clerk's buit-in webserver on the default port 7777,
+;; opening the browser when done
+  (clerk/serve! {:browse? true})
+
+;; let Clerk watch the given `:paths` for changes
+  #_(clerk/serve! {:watch-paths ["notebooks" "src"]})
+  (clerk/serve! {:watch-paths ["src/notebooks"]})
+
+  .)
+

--- a/data-science-from-scratch/clojure/src/notebooks/ch03_visualizations.clj
+++ b/data-science-from-scratch/clojure/src/notebooks/ch03_visualizations.clj
@@ -1,0 +1,9 @@
+(ns notebooks.ch03-visualizations
+  (:require
+   [nextjournal.clerk :as clerk]
+   [meta-csv.core :as csv]))
+
+;; ## Just starting
+
+;; ### Some chart
+;; First, I'd like to print some chart similar to matplotlib


### PR DESCRIPTION
This adds notebooks.clj which can be used to start clerk and watch all the files in src/notebooks/ directory.